### PR TITLE
I definitely screwed this up.. making control plane virtual ip work

### DIFF
--- a/cluster.tf
+++ b/cluster.tf
@@ -38,6 +38,9 @@ resource "talos_machine_configuration_apply" "cp_config_apply" {
   client_configuration        = talos_machine_secrets.machine_secrets.client_configuration
   machine_configuration_input = data.talos_machine_configuration.machineconfig_cp.machine_configuration
   node                        = var.talos_cp_01_ip_addr
+  config_patches = [
+    templatefile("./templates/cpnetwork.yaml.tmpl", {cpip = var.cp_vip})
+  ]
 }
 
 resource "talos_machine_configuration_apply" "cp_config_apply_02" {
@@ -45,6 +48,9 @@ resource "talos_machine_configuration_apply" "cp_config_apply_02" {
   client_configuration        = talos_machine_secrets.machine_secrets.client_configuration
   machine_configuration_input = data.talos_machine_configuration.machineconfig_cp_02.machine_configuration
   node                        = var.talos_cp_02_ip_addr
+  config_patches = [
+    templatefile("./templates/cpnetwork.yaml.tmpl", {cpip = var.cp_vip})
+  ]
 }
 
 resource "talos_machine_configuration_apply" "cp_config_apply_03" {
@@ -52,6 +58,9 @@ resource "talos_machine_configuration_apply" "cp_config_apply_03" {
   client_configuration        = talos_machine_secrets.machine_secrets.client_configuration
   machine_configuration_input = data.talos_machine_configuration.machineconfig_cp_03.machine_configuration
   node                        = var.talos_cp_03_ip_addr
+  config_patches = [
+    templatefile("./templates/cpnetwork.yaml.tmpl", {cpip = var.cp_vip})
+  ]
 }
 
 # Worker Machine Configurations

--- a/templates/cpnetwork.yaml.tmpl
+++ b/templates/cpnetwork.yaml.tmpl
@@ -1,0 +1,8 @@
+machine:
+  network:
+    interfaces:
+      - deviceSelector:
+          busPath: "0*"
+        dhcp: true
+        vip:
+          ip: ${cpip}

--- a/variables.tf
+++ b/variables.tf
@@ -45,3 +45,7 @@ variable "proxmox_password" {
   sensitive   = true
   description = "Password for Proxmox API access"
 }
+variable "cp_vip" {
+  type    = string
+  default = "192.168.3.180"
+}


### PR DESCRIPTION
This is my attempt to translate what I did to my config (which is a partial not quite faithful copy of your config adjusted a bunch back to your config.  It basically smooshes into terraform this: https://www.talos.dev/v1.9/talos-guides/network/vip/

With a template (because I couldn't get yamlencode to work, it's touchy) I can see I screwed up and left the virtual ip probably wrong for the ips specified in the rest of  your config...  Anyways, first pull request ever so please be kind even though it's very sub par.