### PR TITLE
feat: Add Longhorn Talos setup with kubelet extraMounts

### DIFF
--- a/LONGHORN_TALOS_SETUP.md
+++ b/LONGHORN_TALOS_SETUP.md
@@ -1,10 +1,116 @@
 # Longhorn on Talos Linux - Setup Guide
 
-## Environment Check Results
+## Prerequisites
 
-The Longhorn environment check script shows several warnings/errors that are **expected and safe to ignore** on Talos Linux:
+### Talos Worker Node Configuration
 
-### ✅ Safe to Ignore (Talos-specific)
+**IMPORTANT**: Worker nodes must have kubelet extraMounts configured for Longhorn to work properly. This is already configured in `cluster.tf` for all worker nodes:
+
+```hcl
+config_patches = [
+  yamlencode({
+    machine = {
+      kubelet = {
+        extraMounts = [
+          {
+            destination = "/var/lib/longhorn"
+            type        = "bind"
+            source      = "/var/lib/longhorn"
+            options     = ["bind", "rshared", "rw"]
+          }
+        ]
+      }
+    }
+  })
+]
+```
+
+After applying Terraform changes to worker configurations, **reboot the worker nodes** for kubelet changes to take effect:
+
+```bash
+talosctl reboot --nodes 10.0.0.73
+talosctl reboot --nodes 10.0.0.74
+talosctl reboot --nodes 10.0.0.75
+```
+
+## Quick Installation
+
+Use the provided installation script for a complete setup:
+
+```bash
+./longhorn-install.sh
+```
+
+This script will:
+1. Create the `longhorn-system` namespace with proper pod security labels
+2. Install Longhorn via Helm
+3. Expose the UI on NodePort 30080
+4. Configure storage disks on all worker nodes
+
+## Manual Installation
+
+### Step 1: Create Namespace
+
+```bash
+kubectl create namespace longhorn-system
+kubectl label namespace longhorn-system \
+    pod-security.kubernetes.io/enforce=privileged \
+    pod-security.kubernetes.io/audit=privileged \
+    pod-security.kubernetes.io/warn=privileged
+```
+
+### Step 2: Install Longhorn
+
+```bash
+helm repo add longhorn https://charts.longhorn.io
+helm repo update
+helm install longhorn longhorn/longhorn \
+    --namespace longhorn-system \
+    --set defaultSettings.createDefaultDiskLabeledNodes=true \
+    --set persistence.defaultClassReplicaCount=3
+```
+
+### Step 3: Expose UI
+
+```bash
+kubectl patch svc longhorn-frontend -n longhorn-system \
+    -p '{"spec": {"type": "NodePort", "ports": [{"port": 80, "targetPort": 8000, "nodePort": 30080}]}}'
+```
+
+### Step 4: Configure Storage Disks
+
+```bash
+# For each worker node
+kubectl patch nodes.longhorn.io talos-worker-01 -n longhorn-system --type='merge' \
+    -p '{"spec":{"disks":{"default-disk":{"path":"/var/lib/longhorn","allowScheduling":true,"storageReserved":0}}}}'
+
+kubectl patch nodes.longhorn.io talos-worker-02 -n longhorn-system --type='merge' \
+    -p '{"spec":{"disks":{"default-disk":{"path":"/var/lib/longhorn","allowScheduling":true,"storageReserved":0}}}}'
+
+kubectl patch nodes.longhorn.io talos-worker-03 -n longhorn-system --type='merge' \
+    -p '{"spec":{"disks":{"default-disk":{"path":"/var/lib/longhorn","allowScheduling":true,"storageReserved":0}}}}'
+```
+
+## Access
+
+- **Longhorn UI**: http://<worker-node-ip>:30080
+- **Worker IPs**: 10.0.0.73, 10.0.0.74, 10.0.0.75
+
+## Verification
+
+Check storage status:
+```bash
+kubectl get nodes.longhorn.io -n longhorn-system -o jsonpath='{range .items[*]}{.metadata.name}: {.status.diskStatus.default-disk.storageAvailable}{"\n"}{end}'
+```
+
+Check all pods are running:
+```bash
+kubectl get pods -n longhorn-system
+```
+
+## Talos-Specific Notes
+
+### ✅ Safe to Ignore
 
 1. **Kernel detection failures** - Talos doesn't have bash in nsenter containers
 2. **OS detection failures** - Same reason as above
@@ -12,42 +118,21 @@ The Longhorn environment check script shows several warnings/errors that are **e
 
 ### ✅ Verified Working
 
-All Talos worker nodes have `ext-iscsid` service running:
-```bash
-talosctl services | grep ext-iscsid
-# ext-iscsid   Running
-```
-
-## Talos Configuration Requirements
-
-Longhorn works on Talos with the following considerations:
-
-1. **iSCSI Support**: Talos includes `ext-iscsid` by default (verified running)
-2. **Kernel Version**: 6.12.57-talos (exceeds minimum requirement of 5.8)
-3. **Storage**: Raw block devices available on worker nodes
-
-## Installation
-
-Install Longhorn using the provided values file:
-
-```bash
-helm repo add longhorn https://charts.longhorn.io
-helm repo update
-helm install longhorn longhorn/longhorn \
-  --namespace longhorn-system \
-  --create-namespace \
-  --values longhorn-values.yaml
-```
-
-## Post-Installation
-
-1. Access Longhorn UI via NodePort on port 30080
-2. Manually add disks in the UI for each worker node
-3. Verify volume provisioning works
+- **iSCSI Support**: Talos includes `ext-iscsid` by default
+- **Kernel Version**: 6.12.57-talos (exceeds minimum requirement of 5.8)
+- **MountPropagation**: Enabled via kubelet extraMounts in Terraform
 
 ## Troubleshooting
 
 If volumes fail to attach, verify:
+- Worker nodes were rebooted after Terraform apply
 - `ext-iscsid` is running: `talosctl services`
-- Disks are properly formatted and added in Longhorn UI
+- Disks are configured: `kubectl get nodes.longhorn.io -n longhorn-system`
 - CSI driver pods are healthy: `kubectl get pods -n longhorn-system`
+
+## Uninstall
+
+```bash
+helm uninstall longhorn -n longhorn-system
+kubectl delete ns longhorn-system
+```

--- a/cluster.tf
+++ b/cluster.tf
@@ -102,12 +102,29 @@ resource "talos_machine_configuration_apply" "cp_config_apply_03" {
 
 # Worker Machine Configurations
 # All workers use the VIP as the cluster endpoint for HA
+# Includes Longhorn requirements: kubelet extra mounts for MountPropagation
 data "talos_machine_configuration" "machineconfig_worker" {
   cluster_name       = var.cluster_name
   cluster_endpoint   = "https://${var.cluster_vip}:6443"
   machine_type       = "worker"
   machine_secrets    = talos_machine_secrets.machine_secrets.machine_secrets
   kubernetes_version = var.kubernetes_version
+  config_patches = [
+    yamlencode({
+      machine = {
+        kubelet = {
+          extraMounts = [
+            {
+              destination = "/var/lib/longhorn"
+              type        = "bind"
+              source      = "/var/lib/longhorn"
+              options     = ["bind", "rshared", "rw"]
+            }
+          ]
+        }
+      }
+    })
+  ]
 }
 
 data "talos_machine_configuration" "machineconfig_worker_02" {
@@ -116,6 +133,22 @@ data "talos_machine_configuration" "machineconfig_worker_02" {
   machine_type       = "worker"
   machine_secrets    = talos_machine_secrets.machine_secrets.machine_secrets
   kubernetes_version = var.kubernetes_version
+  config_patches = [
+    yamlencode({
+      machine = {
+        kubelet = {
+          extraMounts = [
+            {
+              destination = "/var/lib/longhorn"
+              type        = "bind"
+              source      = "/var/lib/longhorn"
+              options     = ["bind", "rshared", "rw"]
+            }
+          ]
+        }
+      }
+    })
+  ]
 }
 
 data "talos_machine_configuration" "machineconfig_worker_03" {
@@ -124,6 +157,22 @@ data "talos_machine_configuration" "machineconfig_worker_03" {
   machine_type       = "worker"
   machine_secrets    = talos_machine_secrets.machine_secrets.machine_secrets
   kubernetes_version = var.kubernetes_version
+  config_patches = [
+    yamlencode({
+      machine = {
+        kubelet = {
+          extraMounts = [
+            {
+              destination = "/var/lib/longhorn"
+              type        = "bind"
+              source      = "/var/lib/longhorn"
+              options     = ["bind", "rshared", "rw"]
+            }
+          ]
+        }
+      }
+    })
+  ]
 }
 
 # Apply Worker Configurations

--- a/longhorn-install.sh
+++ b/longhorn-install.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Longhorn Installation Script for Talos Kubernetes Cluster
+# This script installs Longhorn and configures storage on all worker nodes
+
+set -e
+
+echo "=== Longhorn Installation for Talos ==="
+
+# Check prerequisites
+if ! command -v kubectl &> /dev/null; then
+    echo "Error: kubectl is not installed"
+    exit 1
+fi
+
+if ! command -v helm &> /dev/null; then
+    echo "Error: helm is not installed"
+    exit 1
+fi
+
+# Add Longhorn Helm repo
+echo "Adding Longhorn Helm repository..."
+helm repo add longhorn https://charts.longhorn.io 2>/dev/null || true
+helm repo update
+
+# Create namespace with pod security labels
+echo "Creating longhorn-system namespace..."
+kubectl create namespace longhorn-system 2>/dev/null || true
+kubectl label namespace longhorn-system \
+    pod-security.kubernetes.io/enforce=privileged \
+    pod-security.kubernetes.io/audit=privileged \
+    pod-security.kubernetes.io/warn=privileged \
+    --overwrite
+
+# Install Longhorn
+echo "Installing Longhorn..."
+helm upgrade --install longhorn longhorn/longhorn \
+    --namespace longhorn-system \
+    --set defaultSettings.createDefaultDiskLabeledNodes=true \
+    --set persistence.defaultClassReplicaCount=3 \
+    --wait --timeout 5m
+
+# Wait for Longhorn manager pods to be ready
+echo "Waiting for Longhorn manager pods..."
+kubectl wait --for=condition=ready pod -l app=longhorn-manager -n longhorn-system --timeout=300s
+
+# Expose Longhorn UI via NodePort
+echo "Exposing Longhorn UI on NodePort 30080..."
+kubectl patch svc longhorn-frontend -n longhorn-system \
+    -p '{"spec": {"type": "NodePort", "ports": [{"port": 80, "targetPort": 8000, "nodePort": 30080}]}}'
+
+# Get worker nodes
+WORKER_NODES=$(kubectl get nodes --no-headers -o custom-columns=":metadata.name" | grep worker)
+
+# Configure disks on each worker node
+echo "Configuring storage disks on worker nodes..."
+for node in $WORKER_NODES; do
+    echo "  Configuring disk on $node..."
+    kubectl patch nodes.longhorn.io "$node" -n longhorn-system --type='merge' \
+        -p '{"spec":{"disks":{"default-disk":{"path":"/var/lib/longhorn","allowScheduling":true,"storageReserved":0}}}}'
+done
+
+# Wait for disks to be ready
+echo "Waiting for disks to initialize..."
+sleep 10
+
+# Verify disk status
+echo ""
+echo "=== Longhorn Storage Status ==="
+for node in $WORKER_NODES; do
+    STORAGE=$(kubectl get nodes.longhorn.io "$node" -n longhorn-system -o jsonpath='{.status.diskStatus.default-disk.storageAvailable}' 2>/dev/null || echo "0")
+    STORAGE_GB=$((STORAGE / 1024 / 1024 / 1024))
+    echo "  $node: ${STORAGE_GB} GB available"
+done
+
+echo ""
+echo "=== Longhorn Installation Complete ==="
+echo ""
+echo "Longhorn UI available at:"
+echo "  http://<worker-node-ip>:30080"
+echo ""
+echo "Worker node IPs:"
+kubectl get nodes -l '!node-role.kubernetes.io/control-plane' -o wide --no-headers | awk '{print "  " $1 ": " $6}'
+echo ""
+echo "StorageClass 'longhorn' is now the default storage class."


### PR DESCRIPTION
## Summary

This PR adds the necessary IaC configuration and scripts for Longhorn storage on Talos Kubernetes.

## Changes

### cluster.tf
- Added kubelet extraMounts configuration for all worker nodes
- Enables MountPropagation support required by Longhorn
- Bind mounts `/var/lib/longhorn` with `rshared` option

### longhorn-install.sh (new)
- Automated installation script for Longhorn
- Creates namespace with pod security labels
- Installs Longhorn via Helm
- Exposes UI on NodePort 30080
- Configures storage disks on all worker nodes

### LONGHORN_TALOS_SETUP.md
- Complete setup documentation
- Prerequisites and Terraform requirements
- Quick install and manual installation steps
- Verification and troubleshooting guide

## Rebuild Process

1. `terraform apply` (includes kubelet extraMounts)
2. Reboot worker nodes for kubelet changes
3. Run `./longhorn-install.sh`

## Testing

- Verified Longhorn pods all running
- Verified storage disks configured on all 3 worker nodes (~186GB each)
- Verified Longhorn UI accessible on NodePort 30080